### PR TITLE
build - proper module EJS support, (moving away from commonjs require

### DIFF
--- a/src/extras.ts
+++ b/src/extras.ts
@@ -1,10 +1,15 @@
-import { BooleanScore, CategoricalScore, NumericScore, Score } from './game-types';
-import cityShaper from './games/2019-CityShaper';
-import rePlay from './games/2020-RePlay';
-import cargoConnect from './games/2021-CargoConnect';
-import superPowered from './games/2022-SuperPowered';
-import masterPiece from './games/2023-Masterpiece';
-import submerged from './games/2024-Submerged';
+import {
+  BooleanScore,
+  CategoricalScore,
+  NumericScore,
+  Score,
+} from './game-types.js';
+import cityShaper from './games/2019-CityShaper.js';
+import rePlay from './games/2020-RePlay.js';
+import cargoConnect from './games/2021-CargoConnect.js';
+import superPowered from './games/2022-SuperPowered.js';
+import masterPiece from './games/2023-Masterpiece.js';
+import submerged from './games/2024-Submerged.js';
 
 export const isNumericScore = (m: Score): m is NumericScore =>
   m.type === 'numeric';

--- a/src/firebase.links.ts
+++ b/src/firebase.links.ts
@@ -1,4 +1,4 @@
-import { seasons } from 'first-constants';
+import { seasons } from 'first-constants.js';
 
 type Mission = `m${number}${number}`;
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,4 +1,4 @@
-import { Score, ScoreAnswer } from 'game-types';
+import { Score, ScoreAnswer } from 'game-types.js';
 
 export const answer = (res: ScoreAnswer[], q: Score['id']) => {
   try {

--- a/src/game-types.ts
+++ b/src/game-types.ts
@@ -1,4 +1,4 @@
-import { Season } from 'first-constants';
+import { Season } from 'first-constants.js';
 
 export type ScoreAnswer = { id: string; answer: string };
 

--- a/src/games/2019-CityShaper.ts
+++ b/src/games/2019-CityShaper.ts
@@ -1,6 +1,12 @@
-import { ScoreAnswer, Game, Mission, Score, ScoreError } from '../game-types';
-import { Season } from '../first-constants';
-import { answer } from '../functions';
+import {
+  ScoreAnswer,
+  Game,
+  Mission,
+  Score,
+  ScoreError,
+} from '../game-types.js';
+import { Season } from '../first-constants.js';
+import { answer } from '../functions.js';
 
 const SEASON: Season = 20192020;
 

--- a/src/games/2020-RePlay.ts
+++ b/src/games/2020-RePlay.ts
@@ -1,6 +1,12 @@
-import { ScoreAnswer, Game, Mission, Score, ScoreError } from '../game-types';
-import { Season } from '../first-constants';
-import { answer } from '../functions';
+import {
+  ScoreAnswer,
+  Game,
+  Mission,
+  Score,
+  ScoreError,
+} from '../game-types.js';
+import { Season } from '../first-constants.js';
+import { answer } from '../functions.js';
 
 const SEASON: Season = 20202021;
 

--- a/src/games/2021-CargoConnect.ts
+++ b/src/games/2021-CargoConnect.ts
@@ -1,7 +1,13 @@
-import { ScoreAnswer, Game, Mission, Score, ScoreError } from '../game-types';
-import missionPics from '../firebase.links';
-import { Season } from 'first-constants';
-import { answer, nAnswer } from '../functions';
+import {
+  ScoreAnswer,
+  Game,
+  Mission,
+  Score,
+  ScoreError,
+} from '../game-types.js';
+import missionPics from '../firebase.links.js';
+import { Season } from 'first-constants.js';
+import { answer, nAnswer } from '../functions.js';
 
 const SEASON: Season = 20212022;
 const NUM_CONTAINERS = 8;

--- a/src/games/2022-SuperPowered.ts
+++ b/src/games/2022-SuperPowered.ts
@@ -1,7 +1,13 @@
-import { ScoreAnswer, Game, Mission, Score, ScoreError } from '../game-types';
-import { Season } from '../first-constants';
-import missionPics from '../firebase.links';
-import { answer, nAnswer } from '../functions';
+import {
+  ScoreAnswer,
+  Game,
+  Mission,
+  Score,
+  ScoreError,
+} from '../game-types.js';
+import { Season } from '../first-constants.js';
+import missionPics from '../firebase.links.js';
+import { answer, nAnswer } from '../functions.js';
 
 const SEASON: Season = 20222023;
 

--- a/src/games/2023-Masterpiece.ts
+++ b/src/games/2023-Masterpiece.ts
@@ -1,7 +1,13 @@
-import { ScoreAnswer, Game, Mission, Score, ScoreError } from '../game-types';
-import { Season } from '../first-constants';
-import missionPics from '../firebase.links';
-import { answer } from '../functions';
+import {
+  ScoreAnswer,
+  Game,
+  Mission,
+  Score,
+  ScoreError,
+} from '../game-types.js';
+import { Season } from '../first-constants.js';
+import missionPics from '../firebase.links.js';
+import { answer } from '../functions.js';
 
 const SEASON: Season = 20232024;
 

--- a/src/games/2024-Submerged.ts
+++ b/src/games/2024-Submerged.ts
@@ -1,7 +1,13 @@
-import { ScoreAnswer, Game, Mission, Score, ScoreError } from '../game-types';
-import { Season } from '../first-constants';
-import missionPics from '../firebase.links';
-import { answer } from '../functions';
+import {
+  ScoreAnswer,
+  Game,
+  Mission,
+  Score,
+  ScoreError,
+} from '../game-types.js';
+import { Season } from '../first-constants.js';
+import missionPics from '../firebase.links.js';
+import { answer } from '../functions.js';
 
 const SEASON: Season = 20242025;
 
@@ -254,7 +260,7 @@ const missions: Mission[] = [
   },
   {
     prefix: 'm01',
-    title: 'M01 - Coral Nursery 🚳' ,
+    title: 'M01 - Coral Nursery 🚳',
     image: missionPics[SEASON].m01,
   },
   {

--- a/src/games/2025-Unearthed.ts
+++ b/src/games/2025-Unearthed.ts
@@ -1,7 +1,13 @@
-import missionPics from '../firebase.links';
-import { Season } from '../first-constants';
-import { answer, bAnswer, nAnswer } from '../functions';
-import { Game, Mission, Score, ScoreAnswer, ScoreError } from '../game-types';
+import missionPics from '../firebase.links.js';
+import { Season } from '../first-constants.js';
+import { answer, bAnswer, nAnswer } from '../functions.js';
+import {
+  Game,
+  Mission,
+  Score,
+  ScoreAnswer,
+  ScoreError,
+} from '../game-types.js';
 
 const SEASON: Season = 20252026;
 

--- a/src/games/index.ts
+++ b/src/games/index.ts
@@ -1,12 +1,12 @@
-import { seasons } from 'first-constants';
-import { Game } from '../game-types';
-import cityShaper from './2019-CityShaper';
-import rePlay from './2020-RePlay';
-import cargoConnect from './2021-CargoConnect';
-import superPowered from './2022-SuperPowered';
-import masterPiece from './2023-Masterpiece';
-import submerged from './2024-Submerged';
-import unearthed from './2025-Unearthed';
+import { seasons } from 'first-constants.js';
+import { Game } from '../game-types.js';
+import cityShaper from './2019-CityShaper.js';
+import rePlay from './2020-RePlay.js';
+import cargoConnect from './2021-CargoConnect.js';
+import superPowered from './2022-SuperPowered.js';
+import masterPiece from './2023-Masterpiece.js';
+import submerged from './2024-Submerged.js';
+import unearthed from './2025-Unearthed.js';
 
 const games: {
   [key in (typeof seasons)[number]]: Game;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-export * from './game-types';
-export * from './games';
-export { default as games } from './games';
-export * from './extras';
-export * from './first-constants';
-export * from './firebase.links';
-export * from './functions';
+export * from './game-types.js';
+export * from './games/index.js';
+export { default as games } from './games/index.js';
+export * from './extras.js';
+export * from './first-constants.js';
+export * from './firebase.links.js';
+export * from './functions.js';


### PR DESCRIPTION
For context, I am working on moving our main repo `management-sytem` to module js (EJS),

and it was throwing an error on this package as it didn't correctly implement EJS.

Options for this fix:

1. add `.js` to all `import .... <filename>;` lines
2. add dependency & use of `tsup`
   - this is no longer actively maintained since mid 2024
3. use a modern alternative of `tsup` like `tsdown`
   - I was hesitant to choose a package with somewhat smaller monthly downloads & starts over option 1

-----


This should work I hope,

I tested this worked by using `yarn link` to use a local dev copy of this repo in my local dev copy of `management-system`,
It no longer threw runtime errors on this package but went back to internal `management-system` errors